### PR TITLE
ci: disable Qodana scan in pull request workflow

### DIFF
--- a/.github/workflows/pulls.yml
+++ b/.github/workflows/pulls.yml
@@ -35,25 +35,25 @@ jobs:
       - run: pnpm install --frozen-lockfile
       - name: Run tests
         run: pnpm test:coverage
-  qodana:
-    needs: test
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-      pull-requests: write
-      checks: write
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          persist-credentials: false
-          ref: ${{ github.event.pull_request.head.sha }}
-          fetch-depth: 0
-      - name: 'Qodana Scan'
-        uses: JetBrains/qodana-action@v2023.3.2
-        with:
-          upload-result: true
-        env:
-          QODANA_TOKEN: ${{ secrets.QODANA_TOKEN }}
+#  qodana:
+#    needs: test
+#    runs-on: ubuntu-latest
+#    permissions:
+#      contents: write
+#      pull-requests: write
+#      checks: write
+#    steps:
+#      - uses: actions/checkout@v4
+#        with:
+#          persist-credentials: false
+#          ref: ${{ github.event.pull_request.head.sha }}
+#          fetch-depth: 0
+#      - name: 'Qodana Scan'
+#        uses: JetBrains/qodana-action@v2023.3.2
+#        with:
+#          upload-result: true
+#        env:
+#          QODANA_TOKEN: ${{ secrets.QODANA_TOKEN }}
   automerge:
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
Comment out the Qodana scan job in the pull request CI workflow to
temporarily disable static code analysis. This change is done to
speed up the workflow or avoid issues related to Qodana integration
while keeping the configuration for easy re-enabling in the future.