### PR TITLE
feat(client): add ClientProvider with react-query, themes, and flags

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
 		"@radix-ui/react-tooltip": "^1.2.7",
 		"@supabase/supabase-js": "^2.50.3",
 		"@t3-oss/env-nextjs": "^0.13.8",
+		"@tanstack/react-query": "^5.81.5",
 		"@uploadthing/react": "^7.3.2",
 		"class-variance-authority": "^0.7.1",
 		"clsx": "^2.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -35,6 +35,9 @@ importers:
       '@t3-oss/env-nextjs':
         specifier: ^0.13.8
         version: 0.13.8(typescript@5.8.3)(zod@3.25.74)
+      '@tanstack/react-query':
+        specifier: ^5.81.5
+        version: 5.81.5(react@19.1.0)
       '@uploadthing/react':
         specifier: ^7.3.2
         version: 7.3.2(next@15.3.5(@babel/core@7.28.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react@19.1.0)(uploadthing@7.7.3(next@15.3.5(@babel/core@7.28.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(tailwindcss@4.1.11))
@@ -1329,6 +1332,14 @@ packages:
 
   '@tailwindcss/postcss@4.1.11':
     resolution: {integrity: sha512-q/EAIIpF6WpLhKEuQSEVMZNMIY8KhWoAemZ9eylNAih9jxMGAYPPWBn3I9QL/2jZ+e7OEz/tZkX5HwbBR4HohA==}
+
+  '@tanstack/query-core@5.81.5':
+    resolution: {integrity: sha512-ZJOgCy/z2qpZXWaj/oxvodDx07XcQa9BF92c0oINjHkoqUPsmm3uG08HpTaviviZ/N9eP1f9CM7mKSEkIo7O1Q==}
+
+  '@tanstack/react-query@5.81.5':
+    resolution: {integrity: sha512-lOf2KqRRiYWpQT86eeeftAGnjuTR35myTP8MXyvHa81VlomoAWNEd8x5vkcAfQefu0qtYCvyqLropFZqgI2EQw==}
+    peerDependencies:
+      react: ^18 || ^19
 
   '@testing-library/dom@10.4.0':
     resolution: {integrity: sha512-pemlzrSESWbdAloYml3bAJMEfNh1Z7EduzqPKprCH5S341frlpYnUEW0H72dLxa6IsYr+mPno20GiSm+h9dEdQ==}
@@ -5166,6 +5177,13 @@ snapshots:
       '@tailwindcss/oxide': 4.1.11
       postcss: 8.5.6
       tailwindcss: 4.1.11
+
+  '@tanstack/query-core@5.81.5': {}
+
+  '@tanstack/react-query@5.81.5(react@19.1.0)':
+    dependencies:
+      '@tanstack/query-core': 5.81.5
+      react: 19.1.0
 
   '@testing-library/dom@10.4.0':
     dependencies:

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,20 +1,14 @@
 import "~/styles/globals.css";
 
-import {
-	ClerkProvider,
-	SignedIn,
-	SignedOut,
-	SignInButton,
-	UserButton,
-} from "@clerk/nextjs";
+import { ClerkProvider } from "@clerk/nextjs";
 import { GeistSans } from "geist/font/sans";
 import type { Metadata } from "next";
 import { Inter as FontSans } from "next/font/google";
 import type { ReactNode } from "react";
-import { cn } from "~/lib/utils";
+import { Toaster } from "sonner";
 import ClientProvider from "~/components/ClientProvider";
-import {TooltipProvider} from "~/components/ui/tooltip";
-import {Toaster} from "sonner";
+import { TooltipProvider } from "~/components/ui/tooltip";
+import { cn } from "~/lib/utils";
 
 export const metadata: Metadata = {
 	title: "Retro-Board",
@@ -45,10 +39,15 @@ export default function RootLayout({
 				>
 					<ClientProvider>
 						<TooltipProvider>
-							<div className={"relative flex min-h-screen flex-col bg-muted/49"}>
+							<div
+								className={"relative flex min-h-screen flex-col bg-muted/49"}
+							>
 								<div className={"flex size-full flex-col sm:py-2"}>
 									<div>HEADER</div>
-									<main className={"size-full flex-1 p-2 pb-0"} suppressHydrationWarning>
+									<main
+										className={"size-full flex-1 p-2 pb-0"}
+										suppressHydrationWarning
+									>
 										{children}
 									</main>
 								</div>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -12,6 +12,9 @@ import type { Metadata } from "next";
 import { Inter as FontSans } from "next/font/google";
 import type { ReactNode } from "react";
 import { cn } from "~/lib/utils";
+import ClientProvider from "~/components/ClientProvider";
+import {TooltipProvider} from "~/components/ui/tooltip";
+import {Toaster} from "sonner";
 
 export const metadata: Metadata = {
 	title: "Retro-Board",
@@ -40,13 +43,19 @@ export default function RootLayout({
 						fontSans.variable,
 					)}
 				>
-					<SignedOut>
-						<SignInButton />
-					</SignedOut>
-					<SignedIn>
-						<UserButton />
-					</SignedIn>
-					{children}
+					<ClientProvider>
+						<TooltipProvider>
+							<div className={"relative flex min-h-screen flex-col bg-muted/49"}>
+								<div className={"flex size-full flex-col sm:py-2"}>
+									<div>HEADER</div>
+									<main className={"size-full flex-1 p-2 pb-0"} suppressHydrationWarning>
+										{children}
+									</main>
+								</div>
+							</div>
+							<Toaster />
+						</TooltipProvider>
+					</ClientProvider>
 				</body>
 			</html>
 		</ClerkProvider>

--- a/src/components/ClientProvider.tsx
+++ b/src/components/ClientProvider.tsx
@@ -1,0 +1,25 @@
+"use client"
+
+import {type ReactNode, useState} from "react";
+import {QueryClient, QueryClientProvider} from "@tanstack/react-query";
+import {ThemeProvider, useTheme} from "next-themes";
+import {env, flagConfig} from "~/env";
+import {FlagsProvider} from "@flags-gg/react-library";
+
+export default function ClientProvider({children}: {children: ReactNode}) {
+  const {theme} = useTheme();
+  const [queryClient] = useState(() => new QueryClient())
+
+  const flagsConfig = flagConfig
+  flagsConfig.environmentId = env.NEXT_PUBLIC_FLAGS_ENVIRONMENT ?? flagConfig.environmentId
+
+  return (
+    <QueryClientProvider client={queryClient}>
+      <ThemeProvider defaultTheme={theme} enableSystem disableTransitionOnChange attribute={"class"}>
+        <FlagsProvider options={flagsConfig ?? flagsConfig}>
+          {children}
+        </FlagsProvider>
+      </ThemeProvider>
+    </QueryClientProvider>
+  )
+}

--- a/src/components/ClientProvider.tsx
+++ b/src/components/ClientProvider.tsx
@@ -1,25 +1,31 @@
-"use client"
+"use client";
 
-import {type ReactNode, useState} from "react";
-import {QueryClient, QueryClientProvider} from "@tanstack/react-query";
-import {ThemeProvider, useTheme} from "next-themes";
-import {env, flagConfig} from "~/env";
-import {FlagsProvider} from "@flags-gg/react-library";
+import { FlagsProvider } from "@flags-gg/react-library";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { ThemeProvider, useTheme } from "next-themes";
+import { type ReactNode, useState } from "react";
+import { env, flagConfig } from "~/env";
 
-export default function ClientProvider({children}: {children: ReactNode}) {
-  const {theme} = useTheme();
-  const [queryClient] = useState(() => new QueryClient())
+export default function ClientProvider({ children }: { children: ReactNode }) {
+	const { theme } = useTheme();
+	const [queryClient] = useState(() => new QueryClient());
 
-  const flagsConfig = flagConfig
-  flagsConfig.environmentId = env.NEXT_PUBLIC_FLAGS_ENVIRONMENT ?? flagConfig.environmentId
+	const flagsConfig = flagConfig;
+	flagsConfig.environmentId =
+		env.NEXT_PUBLIC_FLAGS_ENVIRONMENT ?? flagConfig.environmentId;
 
-  return (
-    <QueryClientProvider client={queryClient}>
-      <ThemeProvider defaultTheme={theme} enableSystem disableTransitionOnChange attribute={"class"}>
-        <FlagsProvider options={flagsConfig ?? flagsConfig}>
-          {children}
-        </FlagsProvider>
-      </ThemeProvider>
-    </QueryClientProvider>
-  )
+	return (
+		<QueryClientProvider client={queryClient}>
+			<ThemeProvider
+				defaultTheme={theme}
+				enableSystem
+				disableTransitionOnChange
+				attribute={"class"}
+			>
+				<FlagsProvider options={flagsConfig ?? flagsConfig}>
+					{children}
+				</FlagsProvider>
+			</ThemeProvider>
+		</QueryClientProvider>
+	);
 }


### PR DESCRIPTION
Introduce a new ClientProvider component that wraps children with
QueryClientProvider, ThemeProvider, and FlagsProvider to enable React
Query caching, theme management, and feature flags support on the client.

Update the root layout to use ClientProvider, TooltipProvider, and Toaster,
replacing previous auth UI placeholders and improving global state and UI
context management.

Add @tanstack/react-query dependency and update lockfile accordingly.