### PR TITLE
feat: add element ids and update config/schema

### DIFF
--- a/biome.jsonc
+++ b/biome.jsonc
@@ -1,5 +1,5 @@
 {
-	"$schema": "https://biomejs.dev/schemas/2.1.3/schema.json",
+	"$schema": "https://biomejs.dev/schemas/2.2.0/schema.json",
 	"vcs": {
 		"enabled": true,
 		"clientKind": "git",

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
 		"zustand": "^5.0.7"
 	},
 	"devDependencies": {
-		"@biomejs/biome": "^2.1.4",
+		"@biomejs/biome": "^2.2.0",
 		"@jest/environment": "^30.0.5",
 		"@tailwindcss/postcss": "^4.1.12",
 		"@testing-library/jest-dom": "^6.7.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -121,8 +121,8 @@ importers:
         version: 5.0.7(@types/react@19.1.10)(react@19.1.1)(use-sync-external-store@1.5.0(react@19.1.1))
     devDependencies:
       '@biomejs/biome':
-        specifier: ^2.1.4
-        version: 2.1.4
+        specifier: ^2.2.0
+        version: 2.2.0
       '@jest/environment':
         specifier: ^30.0.5
         version: 30.0.5
@@ -370,55 +370,55 @@ packages:
   '@bcoe/v8-coverage@0.2.3':
     resolution: {integrity: sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==}
 
-  '@biomejs/biome@2.1.4':
-    resolution: {integrity: sha512-QWlrqyxsU0FCebuMnkvBIkxvPqH89afiJzjMl+z67ybutse590jgeaFdDurE9XYtzpjRGTI1tlUZPGWmbKsElA==}
+  '@biomejs/biome@2.2.0':
+    resolution: {integrity: sha512-3On3RSYLsX+n9KnoSgfoYlckYBoU6VRM22cw1gB4Y0OuUVSYd/O/2saOJMrA4HFfA1Ff0eacOvMN1yAAvHtzIw==}
     engines: {node: '>=14.21.3'}
     hasBin: true
 
-  '@biomejs/cli-darwin-arm64@2.1.4':
-    resolution: {integrity: sha512-sCrNENE74I9MV090Wq/9Dg7EhPudx3+5OiSoQOkIe3DLPzFARuL1dOwCWhKCpA3I5RHmbrsbNSRfZwCabwd8Qg==}
+  '@biomejs/cli-darwin-arm64@2.2.0':
+    resolution: {integrity: sha512-zKbwUUh+9uFmWfS8IFxmVD6XwqFcENjZvEyfOxHs1epjdH3wyyMQG80FGDsmauPwS2r5kXdEM0v/+dTIA9FXAg==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [darwin]
 
-  '@biomejs/cli-darwin-x64@2.1.4':
-    resolution: {integrity: sha512-gOEICJbTCy6iruBywBDcG4X5rHMbqCPs3clh3UQ+hRKlgvJTk4NHWQAyHOXvaLe+AxD1/TNX1jbZeffBJzcrOw==}
+  '@biomejs/cli-darwin-x64@2.2.0':
+    resolution: {integrity: sha512-+OmT4dsX2eTfhD5crUOPw3RPhaR+SKVspvGVmSdZ9y9O/AgL8pla6T4hOn1q+VAFBHuHhsdxDRJgFCSC7RaMOw==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [darwin]
 
-  '@biomejs/cli-linux-arm64-musl@2.1.4':
-    resolution: {integrity: sha512-nYr7H0CyAJPaLupFE2cH16KZmRC5Z9PEftiA2vWxk+CsFkPZQ6dBRdcC6RuS+zJlPc/JOd8xw3uCCt9Pv41WvQ==}
+  '@biomejs/cli-linux-arm64-musl@2.2.0':
+    resolution: {integrity: sha512-egKpOa+4FL9YO+SMUMLUvf543cprjevNc3CAgDNFLcjknuNMcZ0GLJYa3EGTCR2xIkIUJDVneBV3O9OcIlCEZQ==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [linux]
 
-  '@biomejs/cli-linux-arm64@2.1.4':
-    resolution: {integrity: sha512-juhEkdkKR4nbUi5k/KRp1ocGPNWLgFRD4NrHZSveYrD6i98pyvuzmS9yFYgOZa5JhaVqo0HPnci0+YuzSwT2fw==}
+  '@biomejs/cli-linux-arm64@2.2.0':
+    resolution: {integrity: sha512-6eoRdF2yW5FnW9Lpeivh7Mayhq0KDdaDMYOJnH9aT02KuSIX5V1HmWJCQQPwIQbhDh68Zrcpl8inRlTEan0SXw==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [linux]
 
-  '@biomejs/cli-linux-x64-musl@2.1.4':
-    resolution: {integrity: sha512-lvwvb2SQQHctHUKvBKptR6PLFCM7JfRjpCCrDaTmvB7EeZ5/dQJPhTYBf36BE/B4CRWR2ZiBLRYhK7hhXBCZAg==}
+  '@biomejs/cli-linux-x64-musl@2.2.0':
+    resolution: {integrity: sha512-I5J85yWwUWpgJyC1CcytNSGusu2p9HjDnOPAFG4Y515hwRD0jpR9sT9/T1cKHtuCvEQ/sBvx+6zhz9l9wEJGAg==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [linux]
 
-  '@biomejs/cli-linux-x64@2.1.4':
-    resolution: {integrity: sha512-Eoy9ycbhpJVYuR+LskV9s3uyaIkp89+qqgqhGQsWnp/I02Uqg2fXFblHJOpGZR8AxdB9ADy87oFVxn9MpFKUrw==}
+  '@biomejs/cli-linux-x64@2.2.0':
+    resolution: {integrity: sha512-5UmQx/OZAfJfi25zAnAGHUMuOd+LOsliIt119x2soA2gLggQYrVPA+2kMUxR6Mw5M1deUF/AWWP2qpxgH7Nyfw==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [linux]
 
-  '@biomejs/cli-win32-arm64@2.1.4':
-    resolution: {integrity: sha512-3WRYte7orvyi6TRfIZkDN9Jzoogbv+gSvR+b9VOXUg1We1XrjBg6WljADeVEaKTvOcpVdH0a90TwyOQ6ue4fGw==}
+  '@biomejs/cli-win32-arm64@2.2.0':
+    resolution: {integrity: sha512-n9a1/f2CwIDmNMNkFs+JI0ZjFnMO0jdOyGNtihgUNFnlmd84yIYY2KMTBmMV58ZlVHjgmY5Y6E1hVTnSRieggA==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [win32]
 
-  '@biomejs/cli-win32-x64@2.1.4':
-    resolution: {integrity: sha512-tBc+W7anBPSFXGAoQW+f/+svkpt8/uXfRwDzN1DvnatkRMt16KIYpEi/iw8u9GahJlFv98kgHcIrSsZHZTR0sw==}
+  '@biomejs/cli-win32-x64@2.2.0':
+    resolution: {integrity: sha512-Nawu5nHjP/zPKTIryh2AavzTc/KEg4um/MxWdXW0A6P/RZOyIpa7+QSjeXwAwX/utJGaCoXRPWtF3m5U/bB3Ww==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [win32]
@@ -4428,39 +4428,39 @@ snapshots:
 
   '@bcoe/v8-coverage@0.2.3': {}
 
-  '@biomejs/biome@2.1.4':
+  '@biomejs/biome@2.2.0':
     optionalDependencies:
-      '@biomejs/cli-darwin-arm64': 2.1.4
-      '@biomejs/cli-darwin-x64': 2.1.4
-      '@biomejs/cli-linux-arm64': 2.1.4
-      '@biomejs/cli-linux-arm64-musl': 2.1.4
-      '@biomejs/cli-linux-x64': 2.1.4
-      '@biomejs/cli-linux-x64-musl': 2.1.4
-      '@biomejs/cli-win32-arm64': 2.1.4
-      '@biomejs/cli-win32-x64': 2.1.4
+      '@biomejs/cli-darwin-arm64': 2.2.0
+      '@biomejs/cli-darwin-x64': 2.2.0
+      '@biomejs/cli-linux-arm64': 2.2.0
+      '@biomejs/cli-linux-arm64-musl': 2.2.0
+      '@biomejs/cli-linux-x64': 2.2.0
+      '@biomejs/cli-linux-x64-musl': 2.2.0
+      '@biomejs/cli-win32-arm64': 2.2.0
+      '@biomejs/cli-win32-x64': 2.2.0
 
-  '@biomejs/cli-darwin-arm64@2.1.4':
+  '@biomejs/cli-darwin-arm64@2.2.0':
     optional: true
 
-  '@biomejs/cli-darwin-x64@2.1.4':
+  '@biomejs/cli-darwin-x64@2.2.0':
     optional: true
 
-  '@biomejs/cli-linux-arm64-musl@2.1.4':
+  '@biomejs/cli-linux-arm64-musl@2.2.0':
     optional: true
 
-  '@biomejs/cli-linux-arm64@2.1.4':
+  '@biomejs/cli-linux-arm64@2.2.0':
     optional: true
 
-  '@biomejs/cli-linux-x64-musl@2.1.4':
+  '@biomejs/cli-linux-x64-musl@2.2.0':
     optional: true
 
-  '@biomejs/cli-linux-x64@2.1.4':
+  '@biomejs/cli-linux-x64@2.2.0':
     optional: true
 
-  '@biomejs/cli-win32-arm64@2.1.4':
+  '@biomejs/cli-win32-arm64@2.2.0':
     optional: true
 
-  '@biomejs/cli-win32-x64@2.1.4':
+  '@biomejs/cli-win32-x64@2.2.0':
     optional: true
 
   '@clerk/backend@2.9.2(react-dom@19.1.1(react@19.1.1))(react@19.1.1)':

--- a/src/app/boards/[boardId]/page.tsx
+++ b/src/app/boards/[boardId]/page.tsx
@@ -10,7 +10,7 @@ import {
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { Check, Copy, Plus, Share2 } from "lucide-react";
 import { useParams } from "next/navigation";
-import { useEffect, useState } from "react";
+import { useEffect, useId, useState } from "react";
 import { toast } from "sonner";
 import { BoardColumn } from "~/components/boards/BoardColumn";
 import { BoardSettings } from "~/components/boards/BoardSettings";
@@ -51,6 +51,8 @@ export default function BoardPage() {
 	const [activeCard, setActiveCard] = useState<Card | null>(null);
 	const [shareDialogOpen, setShareDialogOpen] = useState(false);
 	const [copied, setCopied] = useState(false);
+
+	const elemId = useId();
 
 	// Get current user from database
 	const { data: currentUser } = useQuery({
@@ -380,7 +382,7 @@ export default function BoardPage() {
 										<div className="grid gap-2">
 											<Label htmlFor="name">Column Name</Label>
 											<Input
-												id="name"
+												id={`${elemId}-name`}
 												value={columnName}
 												onChange={(e) => setColumnName(e.target.value)}
 												placeholder="What went well?"
@@ -389,7 +391,7 @@ export default function BoardPage() {
 										<div className="grid gap-2">
 											<Label htmlFor="color">Color</Label>
 											<Input
-												id="color"
+												id={`${elemId}-color`}
 												type="color"
 												value={columnColor}
 												onChange={(e) => setColumnColor(e.target.value)}

--- a/src/app/boards/join/[shareId]/page.tsx
+++ b/src/app/boards/join/[shareId]/page.tsx
@@ -3,7 +3,7 @@
 import { useUser } from "@clerk/nextjs";
 import { useMutation, useQuery } from "@tanstack/react-query";
 import { useParams, useRouter } from "next/navigation";
-import { useEffect, useState } from "react";
+import { useEffect, useId, useState } from "react";
 import { Button } from "~/components/ui/button";
 import {
 	Card,
@@ -23,6 +23,8 @@ export default function JoinBoardPage() {
 	const { user, isLoaded } = useUser();
 	const { syncedUser } = useUserSync();
 	const [displayName, setDisplayName] = useState("");
+
+	const elemId = useId();
 
 	// Check for existing anonymous user
 	const { data: anonymousData } = useQuery({
@@ -164,7 +166,7 @@ export default function JoinBoardPage() {
 							<div>
 								<Label htmlFor="displayName">Your Name</Label>
 								<Input
-									id="displayName"
+									id={`${elemId}-displayName`}
 									value={displayName}
 									onChange={(e) => setDisplayName(e.target.value)}
 									placeholder="Enter your name"

--- a/src/app/boards/page.tsx
+++ b/src/app/boards/page.tsx
@@ -4,7 +4,7 @@ import { useUser } from "@clerk/nextjs";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { Calendar, Plus, Users } from "lucide-react";
 import { useRouter } from "next/navigation";
-import { useState } from "react";
+import { useId, useState } from "react";
 import { toast } from "sonner";
 import { Button } from "~/components/ui/button";
 import {
@@ -38,6 +38,8 @@ export default function BoardsPage() {
 	const [open, setOpen] = useState(false);
 	const [name, setName] = useState("");
 	const [description, setDescription] = useState("");
+
+	const elemId = useId();
 
 	const { data: boards, isLoading } = useQuery({
 		queryKey: ["boards", user?.id, syncedUser?.id],
@@ -171,7 +173,7 @@ export default function BoardsPage() {
 							<div className="grid gap-2">
 								<Label htmlFor="name">Board Name</Label>
 								<Input
-									id="name"
+									id={`${elemId}-name`}
 									value={name}
 									onChange={(e) => setName(e.target.value)}
 									placeholder="Sprint 23 Retrospective"
@@ -180,7 +182,7 @@ export default function BoardsPage() {
 							<div className="grid gap-2">
 								<Label htmlFor="description">Description (optional)</Label>
 								<Textarea
-									id="description"
+									id={`${elemId}-description`}
 									value={description}
 									onChange={(e) => setDescription(e.target.value)}
 									placeholder="Retrospective for the end of Sprint 23"

--- a/src/app/poker/[sessionId]/page.tsx
+++ b/src/app/poker/[sessionId]/page.tsx
@@ -12,7 +12,7 @@ import {
 	Share2,
 } from "lucide-react";
 import { useParams } from "next/navigation";
-import { useEffect, useState } from "react";
+import { useEffect, useId, useState } from "react";
 import { toast } from "sonner";
 import { ParticipantList } from "~/components/poker/ParticipantList";
 import { VoteCard } from "~/components/poker/VoteCard";
@@ -74,6 +74,8 @@ export default function PokerSessionPage() {
 	const [selectedVote, setSelectedVote] = useState<string | null>(null);
 	const [shareDialogOpen, setShareDialogOpen] = useState(false);
 	const [copied, setCopied] = useState(false);
+
+	const elemId = useId();
 
 	// Get anonymous user if not logged in
 	const { data: anonymousData } = useQuery({
@@ -477,7 +479,7 @@ export default function PokerSessionPage() {
 									<div className="grid gap-2">
 										<Label htmlFor="title">Story Title</Label>
 										<Input
-											id="title"
+											id={`${elemId}-title`}
 											value={storyTitle}
 											onChange={(e) => setStoryTitle(e.target.value)}
 											placeholder="As a user, I want to..."
@@ -486,7 +488,7 @@ export default function PokerSessionPage() {
 									<div className="grid gap-2">
 										<Label htmlFor="description">Description (optional)</Label>
 										<Textarea
-											id="description"
+											id={`${elemId}-description`}
 											value={storyDescription}
 											onChange={(e) => setStoryDescription(e.target.value)}
 											placeholder="Additional details about the story"

--- a/src/app/poker/join/[shareId]/page.tsx
+++ b/src/app/poker/join/[shareId]/page.tsx
@@ -3,7 +3,7 @@
 import { useUser } from "@clerk/nextjs";
 import { useMutation, useQuery } from "@tanstack/react-query";
 import { useParams, useRouter } from "next/navigation";
-import { useEffect, useState } from "react";
+import { useEffect, useId, useState } from "react";
 import { Button } from "~/components/ui/button";
 import {
 	Card,
@@ -23,6 +23,8 @@ export default function JoinPokerSessionPage() {
 	const { user, isLoaded } = useUser();
 	const { syncedUser } = useUserSync();
 	const [displayName, setDisplayName] = useState("");
+
+	const elemId = useId();
 
 	// Check for existing anonymous user
 	const { data: anonymousData } = useQuery({
@@ -163,7 +165,7 @@ export default function JoinPokerSessionPage() {
 						<div className="space-y-2">
 							<Label htmlFor="name">Your Name</Label>
 							<Input
-								id="name"
+								id={`${elemId}-name`}
 								value={displayName}
 								onChange={(e) => setDisplayName(e.target.value)}
 								placeholder="Enter your name"

--- a/src/app/poker/page.tsx
+++ b/src/app/poker/page.tsx
@@ -4,7 +4,7 @@ import { useUser } from "@clerk/nextjs";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { Calendar, Hash, Plus, Users } from "lucide-react";
 import { useRouter } from "next/navigation";
-import { useState } from "react";
+import { useId, useState } from "react";
 import { toast } from "sonner";
 import { Button } from "~/components/ui/button";
 import {
@@ -40,6 +40,8 @@ export default function PokerPage() {
 	const [description, setDescription] = useState("");
 	const [estimationType, setEstimationType] =
 		useState<EstimationType>("fibonacci");
+
+	const elemId = useId();
 
 	const { data: sessions, isLoading } = useQuery({
 		queryKey: ["poker-sessions", user?.id],
@@ -188,7 +190,7 @@ export default function PokerPage() {
 							<div className="grid gap-2">
 								<Label htmlFor="name">Session Name</Label>
 								<Input
-									id="name"
+									id={`${elemId}-name`}
 									value={name}
 									onChange={(e) => setName(e.target.value)}
 									placeholder="Sprint 23 Planning"
@@ -197,7 +199,7 @@ export default function PokerPage() {
 							<div className="grid gap-2">
 								<Label htmlFor="description">Description (optional)</Label>
 								<Textarea
-									id="description"
+									id={`${elemId}-description`}
 									value={description}
 									onChange={(e) => setDescription(e.target.value)}
 									placeholder="Planning session for upcoming sprint"
@@ -213,19 +215,25 @@ export default function PokerPage() {
 									}
 								>
 									<div className="flex items-center space-x-2">
-										<RadioGroupItem value="fibonacci" id="fibonacci" />
+										<RadioGroupItem
+											value="fibonacci"
+											id={`${elemId}-fibonacci`}
+										/>
 										<Label htmlFor="fibonacci">
 											Fibonacci (1, 2, 3, 5, 8, 13, 21...)
 										</Label>
 									</div>
 									<div className="flex items-center space-x-2">
-										<RadioGroupItem value="tshirt" id="tshirt" />
+										<RadioGroupItem value="tshirt" id={`${elemId}-tshirt`} />
 										<Label htmlFor="tshirt">
 											T-Shirt Sizes (XS, S, M, L, XL, XXL)
 										</Label>
 									</div>
 									<div className="flex items-center space-x-2">
-										<RadioGroupItem value="oneToTen" id="oneToTen" />
+										<RadioGroupItem
+											value="oneToTen"
+											id={`${elemId}-oneToTen`}
+										/>
 										<Label htmlFor="oneToTen">1-10 Scale</Label>
 									</div>
 								</RadioGroup>

--- a/src/components/boards/BoardSettings.tsx
+++ b/src/components/boards/BoardSettings.tsx
@@ -3,7 +3,7 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { Settings, Trash2 } from "lucide-react";
 import { useRouter } from "next/navigation";
-import { useState } from "react";
+import { useId, useState } from "react";
 import { toast } from "sonner";
 import {
 	AlertDialog,
@@ -47,6 +47,8 @@ export function BoardSettings({ board, isOwner }: BoardSettingsProps) {
 	const [creationTime, setCreationTime] = useState(board.creation_time_minutes);
 	const [votingTime, setVotingTime] = useState(board.voting_time_minutes);
 	const [votesPerUser, setVotesPerUser] = useState(board.votes_per_user);
+
+	const elemId = useId();
 
 	// Update board mutation
 	const updateBoardMutation = useMutation({
@@ -131,7 +133,7 @@ export function BoardSettings({ board, isOwner }: BoardSettingsProps) {
 						<div className="space-y-2">
 							<Label htmlFor="name">Board Name</Label>
 							<Input
-								id="name"
+								id={`${elemId}-name`}
 								value={name}
 								onChange={(e) => setName(e.target.value)}
 								placeholder="Board name"
@@ -141,7 +143,7 @@ export function BoardSettings({ board, isOwner }: BoardSettingsProps) {
 						<div className="space-y-2">
 							<Label htmlFor="description">Description (optional)</Label>
 							<Textarea
-								id="description"
+								id={`${elemId}-description`}
 								value={description}
 								onChange={(e) => setDescription(e.target.value)}
 								placeholder="Board description"

--- a/src/components/ui/avatar.tsx
+++ b/src/components/ui/avatar.tsx
@@ -10,7 +10,6 @@ const Avatar = React.forwardRef<
 	React.ComponentPropsWithoutRef<typeof AvatarPrimitive.Root>
 >(({ className, ...props }, ref) => (
 	<AvatarPrimitive.Root
-		// biome-ignore lint/style/noParameterAssign: This is a common pattern for React components
 		ref={ref}
 		className={cn(
 			"relative flex h-10 w-10 shrink-0 overflow-hidden rounded-full",
@@ -26,7 +25,6 @@ const AvatarImage = React.forwardRef<
 	React.ComponentPropsWithoutRef<typeof AvatarPrimitive.Image>
 >(({ className, ...props }, ref) => (
 	<AvatarPrimitive.Image
-		// biome-ignore lint/style/noParameterAssign: This is a common pattern for React components
 		ref={ref}
 		className={cn("aspect-square h-full w-full", className)}
 		{...props}
@@ -39,7 +37,6 @@ const AvatarFallback = React.forwardRef<
 	React.ComponentPropsWithoutRef<typeof AvatarPrimitive.Fallback>
 >(({ className, ...props }, ref) => (
 	<AvatarPrimitive.Fallback
-		// biome-ignore lint/style/noParameterAssign: This is a common pattern for React components
 		ref={ref}
 		className={cn(
 			"flex h-full w-full items-center justify-center rounded-full bg-muted",

--- a/src/components/ui/radio-group.tsx
+++ b/src/components/ui/radio-group.tsx
@@ -14,7 +14,6 @@ const RadioGroup = React.forwardRef<
 		<RadioGroupPrimitive.Root
 			className={cn("grid gap-2", className)}
 			{...props}
-			// biome-ignore lint/style/noParameterAssign: This is a common pattern for React components
 			ref={ref}
 		/>
 	);
@@ -27,7 +26,6 @@ const RadioGroupItem = React.forwardRef<
 >(({ className, ...props }, ref) => {
 	return (
 		<RadioGroupPrimitive.Item
-			// biome-ignore lint/style/noParameterAssign: This is a common pattern for React components
 			ref={ref}
 			className={cn(
 				"aspect-square h-4 w-4 rounded-full border border-primary text-primary shadow focus:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50",

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -1,8 +1,11 @@
 @import "tailwindcss";
 @import "tw-animate-css";
 @import "uploadthing/tw/v4";
+
+/** biome-ignore lint/suspicious/noUnknownAtRules: tailwind **/
 @source "../node_modules/@uploadthing/react/dist";
 
+/** biome-ignore lint/suspicious/noUnknownAtRules: tailwind **/
 @custom-variant dark (&:is(.dark *));
 
 :root {
@@ -74,6 +77,7 @@
 	--sidebar-ring: oklch(0.551 0.027 264.364);
 }
 
+/** biome-ignore lint/suspicious/noUnknownAtRules: tailwind **/
 @theme inline {
 	--radius-sm: calc(var(--radius) - 4px);
 	--radius-md: calc(var(--radius) - 2px);
@@ -134,9 +138,11 @@
 
 @layer base {
 	* {
+		/** biome-ignore lint/suspicious/noUnknownAtRules: tailwind **/
 		@apply border-border outline-ring/50;
 	}
 	body {
+		/** biome-ignore lint/suspicious/noUnknownAtRules: tailwind **/
 		@apply bg-background text-foreground;
 	}
 }

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -77,6 +77,7 @@ class MockHeaders {
 
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any
 	forEach(callbackfn: (value: string, key: string, parent: any) => void) {
+		// biome-ignore lint/suspicious/useIterableCallbackReturn: This is a custom implementation
 		this.headers.forEach((value, key) => callbackfn(value, key, this));
 	}
 }


### PR DESCRIPTION
- Introduce useId-based unique element ids across multiple pages to avoid
  duplicate HTML ids in dynamically rendered components:
  - src/poker/page.ts: add elemId via useId and prefix ids for inputs
    and radio items (name, description, fibonacci, tshirt, oneToTen).
  - src/app/boards/join/[shareId]/page.tsx: add elemId and prefix displayName
    input id.
  - src/app/poker/join/[shareId]/page.tsx: add elemId and prefix name input id.
  This improves accessibility and prevents id collisions when multiple
  instances of the same component render on the page.

- Update biome schema to 2.2.0 in biome.jsonc to stay current with the
  tooling.

- Add a lint suppression comment in test/setup.ts to clarify an intentional
  custom implementation for forEach callback usage and avoid a suspicious
  lint warning.

- Minor import cleanup: import useId where needed alongside useState.