### PR TITLE
test: refine to remove unused values and relax mocks

### DIFF
--- a/src/app/api/boards/[boardId]/cards/route.test.ts
+++ b/src/app/api/boards/[boardId]/cards/route.test.ts
@@ -298,7 +298,7 @@ describe("/api/boards/[boardId]/cards POST", () => {
 			const response = await POST(request, {
 				params: Promise.resolve({ boardId: "board_123" }),
 			});
-			const _data = await response.json();
+			await response.json();
 
 			expect(response.status).toBe(200);
 			expect(currentUser).toHaveBeenCalled();

--- a/src/lib/supabase/client.test.ts
+++ b/src/lib/supabase/client.test.ts
@@ -8,7 +8,7 @@ jest.mock("@supabase/supabase-js", () => ({
 			signOut: jest.fn().mockResolvedValue({ error: null }),
 			getSession: jest.fn().mockResolvedValue({ data: null, error: null }),
 		},
-		from: jest.fn((_table: string) => ({
+		from: jest.fn(() => ({
 			select: jest.fn().mockReturnThis(),
 			insert: jest.fn().mockReturnThis(),
 			update: jest.fn().mockReturnThis(),

--- a/src/test/helpers.ts
+++ b/src/test/helpers.ts
@@ -86,6 +86,7 @@ export function setupSupabaseMocks() {
 
 	// Create chainable object - define it after we have all the mocks
 	// biome-ignore lint/suspicious/noExplicitAny: Mock object needs to be flexible
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
 	const chain: any = {};
 
 	// Create chain methods that return the chain


### PR DESCRIPTION
Remove unused JSON parsing in board cards POST test by awaiting
response.json() without assigning it to a variable. This avoids an
unused variable warning and clarifies that the test only needs the
response body consumed, not inspected. Keep assertions on status and
authentication calls.

Simplify supabase client mock by removing the explicit _table parameter
type in the from() mock. Using a generic jest.fn() makes the mock less
strict and avoids unnecessary TypeScript annotation while preserving
chainable query method behavior.

Add an ESLint disable comment for no-explicit-any where the test helper
declares a flexible chain object. This documents the intentional use of
any for a flexible mock and prevents lint failures.