### PR TITLE
feat(boards): participant boards and restrict column

### DIFF
--- a/src/components/boards/BoardColumn.tsx
+++ b/src/components/boards/BoardColumn.tsx
@@ -189,15 +189,27 @@ export function BoardColumn({
 									Waiting for all participants to join
 								</div>
 							) : (
-								<Button
-									variant="ghost"
-									className="mt-2 w-full justify-start"
-									onClick={() => setIsAddingCard(true)}
-								>
-									<Plus className="mr-2 h-4 w-4" />
-									Add a card
-								</Button>
-							)}
+								column.is_action ? (
+									isOwner && (
+										<Button
+											variant="ghost"
+											className="mt-2 w-full justify-start"
+											onClick={() => setIsAddingCard(true)}
+										>
+											<Plus className="mr-2 h-4 w-4" />
+											Add a card
+										</Button>
+									)
+								) : (
+									<Button
+										variant="ghost"
+										className="mt-2 w-full justify-start"
+										onClick={() => setIsAddingCard(true)}
+									>
+										<Plus className="mr-2 h-4 w-4" />
+										Add a card
+									</Button>
+							))}
 						</>
 					)}
 				</CardContent>


### PR DESCRIPTION
Fetch where the current user is either the owner or a participant.
Split queries into owned boards and participant-linked boards, deduplicate
and sort by created_at descending before returning. This ensures the UI
shows all relevant boards for the user.

In BoardColumn, restrict the "Add a card" button on action columns so it
is visible only to the board owner. Preserve existing behavior for
non-action columns. This prevents non-owners from adding cards to action
columns.