### PR TITLE
feat(timer+logging): add timer extension UI and logs

### DIFF
--- a/src/app/boards/[boardId]/page.tsx
+++ b/src/app/boards/[boardId]/page.tsx
@@ -125,34 +125,27 @@ export default function BoardPage() {
 
 	// Subscribe to realtime updates
 	useEffect(() => {
-		console.log("Setting up real-time subscription for board:", boardId);
 		const boardChannel = new BoardChannel(boardId, supabase);
 
 		boardChannel.subscribe({
-			onCardCreated: (payload) => {
-				console.log("Card created:", payload);
+			onCardCreated: () => {
 				queryClient.invalidateQueries({ queryKey: ["board", boardId] });
 			},
-			onCardUpdated: (payload) => {
-				console.log("Card updated:", payload);
+			onCardUpdated: () => {
 				queryClient.invalidateQueries({ queryKey: ["board", boardId] });
 			},
-			onCardDeleted: (payload) => {
-				console.log("Card deleted:", payload);
+			onCardDeleted: () => {
 				queryClient.invalidateQueries({ queryKey: ["board", boardId] });
 			},
-			onCardsCombined: (payload) => {
-				console.log("Cards combined:", payload);
+			onCardsCombined: () => {
 				queryClient.invalidateQueries({ queryKey: ["board", boardId] });
 				toast("Cards have been combined");
 			},
-			onCardHighlighted: (payload) => {
-				console.log("Card highlighted:", payload);
+			onCardHighlighted: () => {
 				// TODO: Add visual highlighting effect
 				queryClient.invalidateQueries({ queryKey: ["board", boardId] });
 			},
 			onTimerEvent: (payload) => {
-				console.log("Timer event:", payload);
 				queryClient.invalidateQueries({ queryKey: ["board", boardId] });
 				if (payload.action === "start" || payload.action === "resume") {
 					toast("Timer started");
@@ -163,12 +156,10 @@ export default function BoardPage() {
 				}
 			},
 			onPhaseChanged: (payload) => {
-				console.log("Phase changed:", payload);
 				queryClient.invalidateQueries({ queryKey: ["board", boardId] });
 				toast(`Board moved to ${payload.newPhase} phase`);
 			},
-			onBoardUpdated: (payload) => {
-				console.log("Board updated:", payload);
+			onBoardUpdated: () => {
 				queryClient.invalidateQueries({ queryKey: ["board", boardId] });
 			},
 		});

--- a/src/lib/supabase/channels-client.ts
+++ b/src/lib/supabase/channels-client.ts
@@ -52,9 +52,11 @@ export class BoardChannel {
 	private channel: RealtimeChannel | null = null;
 	private boardId: string;
 	// biome-ignore lint/suspicious/noExplicitAny: Supabase client type is complex and varies
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
 	private supabase: any;
 
 	// biome-ignore lint/suspicious/noExplicitAny: Supabase client type is complex and varies
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
 	constructor(boardId: string, supabaseClient: any) {
 		this.boardId = boardId;
 		this.supabase = supabaseClient;
@@ -145,7 +147,10 @@ export class BoardChannel {
 						table: "cards",
 					},
 					(payload) => {
-						console.log("Database change:", payload);
+						// Only log in development
+						if (process.env.NODE_ENV === "development") {
+							console.log("Database change:", payload);
+						}
 					},
 				)
 				.subscribe();

--- a/src/lib/supabase/channels-server.ts
+++ b/src/lib/supabase/channels-server.ts
@@ -28,7 +28,10 @@ export async function broadcastToBoard(
 			event,
 			payload,
 		});
-		console.log(`Broadcast sent: ${event} to board:${boardId}`, payload);
+		// Only log in development
+		if (process.env.NODE_ENV !== "production") {
+			console.log(`Broadcast sent: ${event} to board:${boardId}`, payload);
+		}
 	} catch (error) {
 		console.error("Failed to broadcast event:", error);
 	}


### PR DESCRIPTION
Add a timer extension mutation and UI buttons to owners to extend the timer by 30, 1, or 5m. Show those compact buttonsonly while a phase end time exists and during creation/voting phases. Use sonner toast notifications on success invalidate the board query to refresh state.

Silence verbose logging in production by wrapping console.log calls in NODE_ENV checks in channels-client.ts and channels-server.ts. Also add eslint disable comments for explicit any on Supabase client properties to address lint noise.