### PR TITLE
k-branch-1

### DIFF
--- a/src/app/boards/[boardId]/page.tsx
+++ b/src/app/boards/[boardId]/page.tsx
@@ -487,6 +487,7 @@ export default function BoardPage() {
 										anonymousUser={anonymousData?.user}
 										boardPhase={board.phase}
 										phaseStartedAt={board.phase_started_at}
+										phaseEndsAt={board.phase_ends_at}
 									/>
 								))}
 							</div>

--- a/src/app/boards/page.tsx
+++ b/src/app/boards/page.tsx
@@ -27,7 +27,6 @@ import { Input } from "~/components/ui/input";
 import { Label } from "~/components/ui/label";
 import { Textarea } from "~/components/ui/textarea";
 import { useUserSync } from "~/hooks/useUserSync";
-import { supabase } from "~/lib/supabase/client";
 import type { BoardWithParticipants } from "~/types/database";
 
 export default function BoardsPage() {
@@ -42,69 +41,27 @@ export default function BoardsPage() {
 	const elemId = useId();
 
 	const { data: boards, isLoading } = useQuery({
-		queryKey: ["boards", user?.id, syncedUser?.id],
+		queryKey: ["boards", user?.id],
 		queryFn: async () => {
-			if (!user || !syncedUser) return [];
-
-			// Fetch boards where user is owner or participant
-			const { data: ownedBoards, error: ownedError } = await supabase
-				.from("boards")
-				.select(`
-          *,
-          participants:board_participants(
-            *,
-            user:users(*)
-          )
-        `)
-				.eq("owner_id", syncedUser.id)
-				.order("created_at", { ascending: false });
-
-			if (ownedError) throw ownedError;
-
-			// Fetch boards where user is a participant
-			const { data: participantBoards, error: participantError } =
-				await supabase
-					.from("board_participants")
-					.select(`
-          board:boards(
-            *,
-            participants:board_participants(
-              *,
-              user:users(*)
-            )
-          )
-        `)
-					.eq("user_id", syncedUser.id)
-					.order("created_at", { ascending: false });
-
-			if (participantError) throw participantError;
-
-			// Combine and deduplicate boards
-			const allBoards = [...(ownedBoards || [])];
-			const boardIds = new Set(allBoards.map((b) => b.id));
-
-			// Add participant boards that aren't already in the list
-			if (participantBoards) {
-				// biome-ignore lint/suspicious/noExplicitAny: Supabase query result type
-				// eslint-disable-next-line @typescript-eslint/no-explicit-any
-				for (const pb of participantBoards as any[]) {
-					// Type assertion for the nested board object
-					const board = pb?.board as BoardWithParticipants | undefined;
-					if (board?.id && !boardIds.has(board.id)) {
-						allBoards.push(board);
-					}
-				}
+			if (!user) {
+				console.log("No user:", { user });
+				return [];
 			}
 
-			// Sort by created_at descending
-			allBoards.sort(
-				(a, b) =>
-					new Date(b.created_at).getTime() - new Date(a.created_at).getTime(),
-			);
+			console.log("Fetching boards via API");
 
-			return allBoards as BoardWithParticipants[];
+			const response = await fetch("/api/boards");
+			if (!response.ok) {
+				const error = await response.json();
+				console.error("Error fetching boards:", error);
+				throw new Error(error.error || "Failed to fetch boards");
+			}
+
+			const data = await response.json();
+			console.log("Boards fetched from API:", data.boards);
+			return data.boards as BoardWithParticipants[];
 		},
-		enabled: !!user && !!syncedUser,
+		enabled: !!user && isLoaded,
 	});
 
 	const createBoardMutation = useMutation({
@@ -155,7 +112,7 @@ export default function BoardsPage() {
 		}
 	};
 
-	if (!isLoaded || isLoading || (user && !syncedUser)) {
+	if (!isLoaded || isLoading) {
 		return (
 			<div className="container mx-auto py-8">
 				<div className="flex h-64 items-center justify-center">

--- a/src/components/ClientProvider.tsx
+++ b/src/components/ClientProvider.tsx
@@ -14,8 +14,6 @@ export default function ClientProvider({ children }: { children: ReactNode }) {
 	flagsConfig.environmentId =
 		env.NEXT_PUBLIC_FLAGS_ENVIRONMENT ?? flagConfig.environmentId;
 
-	console.info("Flags", flagsConfig);
-
 	return (
 		<QueryClientProvider client={queryClient}>
 			<ThemeProvider

--- a/src/components/boards/BoardColumn.tsx
+++ b/src/components/boards/BoardColumn.tsx
@@ -27,7 +27,8 @@ interface BoardColumnProps {
 	isOwner?: boolean;
 	anonymousUser?: AnonymousUser;
 	boardPhase?: Board["phase"];
-	phaseStartedAt?: Date;
+	phaseStartedAt?: Date | string | null;
+	phaseEndsAt?: Date | string | null;
 }
 
 export function BoardColumn({
@@ -39,6 +40,7 @@ export function BoardColumn({
 	anonymousUser,
 	boardPhase,
 	phaseStartedAt,
+	phaseEndsAt,
 }: BoardColumnProps) {
 	const queryClient = useQueryClient();
 	const [isAddingCard, setIsAddingCard] = useState(false);
@@ -134,6 +136,7 @@ export function BoardColumn({
 									currentAnonymousUserId={anonymousUser?.id}
 									boardId={boardId}
 									boardPhase={boardPhase}
+									isActionColumn={column.is_action}
 								/>
 							))}
 						</div>
@@ -195,6 +198,29 @@ export function BoardColumn({
 								!phaseStartedAt ? (
 								<div className="mt-2 rounded-md bg-muted p-2 text-center text-muted-foreground text-sm">
 									Waiting for timer to start
+								</div>
+							) : boardPhase === "creation" &&
+								!column.is_action &&
+								phaseStartedAt &&
+								!phaseEndsAt ? (
+								<div className="mt-2 rounded-md bg-muted p-2 text-center text-muted-foreground text-sm">
+									Timer is paused - cards cannot be added
+								</div>
+							) : boardPhase === "voting" && phaseStartedAt && !phaseEndsAt ? (
+								<div className="mt-2 rounded-md bg-muted p-2 text-center text-muted-foreground text-sm">
+									Voting is paused
+								</div>
+							) : boardPhase === "reveal" || boardPhase === "voting" ? (
+								<div className="mt-2 rounded-md bg-muted p-2 text-center text-muted-foreground text-sm">
+									Cards cannot be added during {boardPhase}
+								</div>
+							) : boardPhase === "discussion" && !column.is_action ? (
+								<div className="mt-2 rounded-md bg-muted p-2 text-center text-muted-foreground text-sm">
+									Only action items can be added during discussion
+								</div>
+							) : boardPhase === "completed" ? (
+								<div className="mt-2 rounded-md bg-muted p-2 text-center text-muted-foreground text-sm">
+									Board is completed
 								</div>
 							) : column.is_action ? (
 								isOwner && (

--- a/src/components/boards/Card.tsx
+++ b/src/components/boards/Card.tsx
@@ -19,6 +19,7 @@ interface CardProps {
 	boardId: string;
 	isDragging?: boolean;
 	boardPhase?: Board["phase"];
+	isActionColumn?: boolean;
 }
 
 export function Card({
@@ -28,6 +29,7 @@ export function Card({
 	boardId,
 	isDragging,
 	boardPhase,
+	isActionColumn,
 }: CardProps) {
 	const queryClient = useQueryClient();
 	const [isEditing, setIsEditing] = useState(false);
@@ -168,7 +170,9 @@ export function Card({
 		(currentUserId && currentUserId === card.author_id) ||
 		(currentAnonymousUserId &&
 			currentAnonymousUserId === card.anonymous_author_id);
-	const isMasked = card.is_masked && boardPhase === "creation" && !isOwner;
+	// Action cards are never masked, regular cards are masked during creation (except for owner)
+	const isMasked =
+		!isActionColumn && card.is_masked && boardPhase === "creation" && !isOwner;
 
 	return (
 		<div
@@ -224,7 +228,7 @@ export function Card({
 						<>
 							<p className="mb-2 whitespace-pre-wrap text-sm">{card.content}</p>
 							<div className="flex items-center justify-between">
-								{boardPhase === "voting" && (
+								{boardPhase === "voting" && !isActionColumn && (
 									<Button
 										size="sm"
 										variant="ghost"
@@ -239,12 +243,14 @@ export function Card({
 										{voteCount}
 									</Button>
 								)}
-								{boardPhase !== "voting" && voteCount > 0 && (
-									<div className="flex items-center text-muted-foreground text-sm">
-										<ThumbsUp className="mr-1 h-3 w-3" />
-										{voteCount}
-									</div>
-								)}
+								{boardPhase !== "voting" &&
+									voteCount > 0 &&
+									!isActionColumn && (
+										<div className="flex items-center text-muted-foreground text-sm">
+											<ThumbsUp className="mr-1 h-3 w-3" />
+											{voteCount}
+										</div>
+									)}
 								{isOwner && (
 									<div className="flex gap-1">
 										<Button

--- a/src/test/helpers.ts
+++ b/src/test/helpers.ts
@@ -27,6 +27,7 @@ export const mockBoard = {
 	share_id: "share_123",
 	phase: "creation" as const,
 	phase_started_at: new Date().toISOString(), // Timer has started
+	phase_ends_at: new Date(Date.now() + 5 * 60 * 1000).toISOString(), // Timer is running (5 minutes)
 	creation_time_minutes: 5,
 	voting_time_minutes: 3,
 	votes_per_user: 5,


### PR DESCRIPTION
Summary
- Prevent card creation for non-action columns when board timer is paused; return 403 with a clear error.
- Disallow adding cards during the reveal phase and provide specific error for voting phase.
- Ensure action cards are never masked; only mask non-action cards in creation phase.
- Add unit test ensuring card creation is rejected when timer is paused in creation phase.
- Prevent voting on cards in action columns by returning 400 when attempted.
- Add isActionColumn prop to Card component for future UI logic.
- Update user sync to fetch full user record and perform updates (email, name, avatar_url, updated_at).
- Add GET /api/boards to return authenticated user's owned and participant boards (deduplicated, filtered, sorted).
- Remove unused Supabase client import and simplify client-side boards query key to depend only on user id.