### PR TITLE
feat(poker): add vote-change handling and auto-finalize grace

### DIFF
--- a/src/app/api/poker-sessions/[sessionId]/score/route.ts
+++ b/src/app/api/poker-sessions/[sessionId]/score/route.ts
@@ -179,7 +179,9 @@ export async function POST(
 		// Format votes for response
 		const voteMap: Record<string, string> = {};
 		for (const vote of votes) {
+			// biome-ignore lint/suspicious/noExplicitAny: Supabase join type
 			const user = vote.users as any;
+			// biome-ignore lint/suspicious/noExplicitAny: Supabase join type
 			const anonUser = vote.anonymous_users as any;
 			const voterName =
 				user?.name || user?.email || anonUser?.display_name || "Anonymous";

--- a/src/hooks/usePokerChannel.test.ts
+++ b/src/hooks/usePokerChannel.test.ts
@@ -21,6 +21,7 @@ jest.mock("~/lib/supabase/poker-channel", () => ({
 describe("usePokerChannel", () => {
 	const mockUser = { id: "user-123", fullName: "John Doe" };
 	const sessionId = "session-123";
+	// biome-ignore lint/suspicious/noExplicitAny: Mock object for testing
 	let mockChannelInstance: any;
 
 	beforeEach(() => {
@@ -53,7 +54,7 @@ describe("usePokerChannel", () => {
 
 	describe("channel connection", () => {
 		it("should connect to channel on mount", async () => {
-			const { result } = renderHook(() =>
+			renderHook(() =>
 				usePokerChannel({
 					sessionId,
 					isAnonymous: false,
@@ -76,7 +77,7 @@ describe("usePokerChannel", () => {
 			(useUser as jest.Mock).mockReturnValue({ user: null });
 			const anonymousUserId = "anon-123";
 
-			const { result } = renderHook(() =>
+			renderHook(() =>
 				usePokerChannel({
 					sessionId,
 					isAnonymous: true,
@@ -117,6 +118,7 @@ describe("usePokerChannel", () => {
 
 		beforeEach(() => {
 			// Capture the message handler
+			// biome-ignore lint/suspicious/noExplicitAny: Mock handler for testing
 			mockChannelInstance.onMessage.mockImplementation((handler: any) => {
 				messageHandler = handler;
 				return jest.fn(); // Return unsubscribe function


### PR DESCRIPTION
Describe vote counting and auto-finalize behavior more robustly.
- Track votesReceived only on first-time votes so vote changes do not
  inflate the count. Preserve votesReceived when voters change their
  previous vote while still recomputing allVoted based on current
  eligible voters.
-compute eligibleVoters and allVoted whenever participants or their
  abstain status changes to ensure votingState stays consistent.

Introduce a 10s grace period before automatic finalization when all
eligible voters have voted. The effect:
- defers call to handleFinalizeVoting for 10s to allow last-moment
  vote changes.
- cancels/restarts the grace period when votes change or dependencies
  update.
- avoids auto-finalizing if timer is not active or finalization is
  already in progress.

Testing and lint adjustments:
- Update tests to use renderHook without unused result variable.
- Add biome-ignore comments where mocks or Supabase join types require
  explicit any usage.
- Add mock handler and channel instance any-typing in tests to satisfy
  runtime mocking requirements.

Fixes race and correctness issues around vote counting and automated
finalization, reducing false positives for "all votes received" and
giving participants a short window to change votes.