### PR TITLE
feat(poker): reveal votes and autoalc consensus on reveal

### DIFF
--- a/src/app/poker/[sessionId]/page.tsx
+++ b/src/app/poker/[sessionId]/page.tsx
@@ -548,6 +548,11 @@ export default function PokerSessionPage() {
 
 				const { finalScore, votes } = await scoreResponse.json();
 
+				// Stop the timer if it's running
+				if (sessionState.timer?.isActive) {
+					await stopTimer();
+				}
+
 				// End voting and announce score through the channel
 				await endVoting(currentStory.id);
 				await announceScore(currentStory.id, finalScore, votes);


### PR DESCRIPTION
When toggling vote reveal, detect when revealing votes for a story
that has collected votes but lacks a final estimate. In that case:
- PATCH the session to reveal votes first.
- POST to the session score endpoint to calculate and persist
  the consensus score for the current story.
- Call endVoting and announceScore to finalize and broadcast the
  result.
- Show a success toast with the final score.

When not in that special case (hiding votes or revealing with no
votes), simply toggle the reveal_votes flag on the session.

This ensures that revealing votes triggers automatic consensus
calculation and proper end-of-vote actions, avoiding manual steps
and keeping UI and backend state in sync.