### PR TITLE
feat(poker): show prominent consensus result after reveal

### DIFF
--- a/src/app/api/poker-sessions/[sessionId]/votes/route.ts
+++ b/src/app/api/poker-sessions/[sessionId]/votes/route.ts
@@ -278,8 +278,8 @@ export async function DELETE(
 
 		// Also clear the final_estimate for the story
 		const { error: updateError } = await supabaseAdmin
-			.from("poker_stories")
-			.update({ final_estimate: null, estimated_at: null })
+			.from("stories")
+			.update({ final_estimate: null, is_estimated: false, estimated_at: null })
 			.eq("id", storyId);
 
 		if (updateError) {

--- a/src/app/api/poker-sessions/[sessionId]/votes/route.ts
+++ b/src/app/api/poker-sessions/[sessionId]/votes/route.ts
@@ -222,3 +222,78 @@ export async function POST(
 		);
 	}
 }
+
+export async function DELETE(
+	request: Request,
+	{ params }: { params: Promise<{ sessionId: string }> },
+) {
+	try {
+		const resolvedParams = await params;
+		const { userId } = await auth();
+
+		if (!userId) {
+			return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+		}
+
+		// Get user from database
+		const { data: dbUser } = await supabaseAdmin
+			.from("users")
+			.select("id")
+			.eq("clerk_id", userId)
+			.single();
+
+		if (!dbUser) {
+			return NextResponse.json({ error: "User not found" }, { status: 404 });
+		}
+
+		// Check if user is the facilitator
+		const { data: session } = await supabaseAdmin
+			.from("poker_sessions")
+			.select("created_by")
+			.eq("id", resolvedParams.sessionId)
+			.single();
+
+		if (!session || session.created_by !== dbUser.id) {
+			return NextResponse.json(
+				{ error: "Only facilitator can reset votes" },
+				{ status: 403 },
+			);
+		}
+
+		const body = await request.json();
+		const { storyId } = body;
+
+		// Delete all votes for this story
+		const { error: deleteError } = await supabaseAdmin
+			.from("poker_votes")
+			.delete()
+			.eq("story_id", storyId);
+
+		if (deleteError) {
+			return NextResponse.json(
+				{ error: "Failed to delete votes" },
+				{ status: 500 },
+			);
+		}
+
+		// Also clear the final_estimate for the story
+		const { error: updateError } = await supabaseAdmin
+			.from("poker_stories")
+			.update({ final_estimate: null, estimated_at: null })
+			.eq("id", storyId);
+
+		if (updateError) {
+			console.error("Error clearing story estimate:", updateError);
+		}
+
+		return NextResponse.json({ success: true });
+	} catch (error) {
+		console.error("Error deleting votes:", error);
+		return NextResponse.json(
+			{
+				error: error instanceof Error ? error.message : "Internal server error",
+			},
+			{ status: 500 },
+		);
+	}
+}

--- a/src/app/poker/[sessionId]/page.tsx
+++ b/src/app/poker/[sessionId]/page.tsx
@@ -83,6 +83,10 @@ export default function PokerSessionPage() {
 	const [isAbstaining, setIsAbstaining] = useState(false);
 	const [displayTime, setDisplayTime] = useState("0:00");
 	const [isFinalizingVoting, setIsFinalizingVoting] = useState(false);
+	const [showConsensusResult, setShowConsensusResult] = useState<{
+		score: string;
+		storyTitle: string;
+	} | null>(null);
 
 	const elemId = useId();
 
@@ -251,7 +255,16 @@ export default function PokerSessionPage() {
 						body: JSON.stringify({ reveal_votes: true }),
 					});
 
-					toast.success(`Story estimated: ${finalScore}`);
+					// Show prominent consensus result
+					setShowConsensusResult({
+						score: finalScore,
+						storyTitle: currentStory.title,
+					});
+
+					// Clear after 5 seconds
+					setTimeout(() => {
+						setShowConsensusResult(null);
+					}, 5000);
 				}
 			} else {
 				// No votes received
@@ -493,6 +506,7 @@ export default function PokerSessionPage() {
 			queryClient.invalidateQueries({ queryKey: ["poker-session", sessionId] });
 			setSelectedVote(null);
 			setIsFinalizingVoting(false); // Reset when new story is selected
+			setShowConsensusResult(null); // Clear any previous consensus display
 		},
 	});
 
@@ -554,7 +568,16 @@ export default function PokerSessionPage() {
 				await endVoting(currentStory.id);
 				await announceScore(currentStory.id, finalScore, votes);
 
-				toast.success(`Story estimated: ${finalScore}`);
+				// Show prominent consensus result
+				setShowConsensusResult({
+					score: finalScore,
+					storyTitle: currentStory.title,
+				});
+
+				// Clear after 5 seconds
+				setTimeout(() => {
+					setShowConsensusResult(null);
+				}, 5000);
 
 				return revealResponse.json();
 			}
@@ -847,6 +870,34 @@ export default function PokerSessionPage() {
 					)}
 				</div>
 			</div>
+
+			{/* Prominent Consensus Result Display */}
+			{showConsensusResult && (
+				<div className="slide-in-from-top mb-8 animate-in duration-500">
+					<Card className="border-green-500 bg-gradient-to-r from-green-50 to-emerald-50 dark:from-green-950 dark:to-emerald-950">
+						<CardContent className="p-8">
+							<div className="flex flex-col items-center justify-center gap-4">
+								<div className="flex items-center gap-2">
+									<CheckCircle2 className="h-8 w-8 text-green-600 dark:text-green-400" />
+									<h2 className="font-bold text-2xl text-green-900 dark:text-green-100">
+										Consensus Reached!
+									</h2>
+								</div>
+								<div className="text-center">
+									<p className="mb-2 text-gray-700 text-lg dark:text-gray-300">
+										{showConsensusResult.storyTitle}
+									</p>
+									<div className="inline-flex items-center justify-center">
+										<span className="rounded-xl bg-white px-8 py-4 font-bold text-5xl text-green-700 shadow-lg dark:bg-gray-900 dark:text-green-300">
+											{showConsensusResult.score}
+										</span>
+									</div>
+								</div>
+							</div>
+						</CardContent>
+					</Card>
+				</div>
+			)}
 
 			<div className="grid grid-cols-1 gap-8 lg:grid-cols-3">
 				<div className="space-y-6 lg:col-span-2">

--- a/src/app/poker/[sessionId]/page.tsx
+++ b/src/app/poker/[sessionId]/page.tsx
@@ -581,7 +581,7 @@ export default function PokerSessionPage() {
 
 				return revealResponse.json();
 			}
-			
+
 			// If hiding votes (resetting for another round of voting)
 			if (!isRevealing && currentStory) {
 				// Hide the votes
@@ -621,7 +621,7 @@ export default function PokerSessionPage() {
 
 				// Clear the selected vote
 				setSelectedVote(null);
-				
+
 				// Clear consensus display if showing
 				setShowConsensusResult(null);
 
@@ -629,7 +629,7 @@ export default function PokerSessionPage() {
 
 				return response.json();
 			}
-			
+
 			// Default case - just toggle reveal state
 			const response = await fetch(`/api/poker-sessions/${sessionId}`, {
 				method: "PATCH",


### PR DESCRIPTION
Add a transient result banner to the poker page
that prominently displays the story title and final score when votes
are revealed and a consensus is reached.

- Introduce showConsensusResult state to hold score and story title.
- Set showConsensusResult when revealing or announcing a final score,
  and clear it after 5 seconds.
- Clear the consensus display when selecting a new story.
- Render a styled Card banner at the top of the session UI to highlight
  the consensus with title and large score, including entrance animation.

This makes the final estimate more visible to participants and improves
feedback after voting completes.